### PR TITLE
electron-edge-js v30.0.2 破壊的変更対応

### DIFF
--- a/EdgeJsCSharpSharedLib/EdgeJsCSharpSharedLib/EdgeJsCSharpSharedLib.csproj
+++ b/EdgeJsCSharpSharedLib/EdgeJsCSharpSharedLib/EdgeJsCSharpSharedLib.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Edge.js.CSharp" Version="1.2.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.3" />
   </ItemGroup>
 
 </Project>

--- a/EdgeJsCSharpSharedLib/EdgeJsCSharpSharedLib/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/EdgeJsCSharpSharedLib/EdgeJsCSharpSharedLib/Properties/PublishProfiles/FolderProfile.pubxml
@@ -9,6 +9,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>..\..\electron-app\SharedLibraries</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@
     * ワークロードは下記を選択する。
         * C++ によるデスクトップ開発
         * .NET デスクトップ ビルド ツール
-1. Node.js 18.14.2
-1. Python 3.11.0
+1. Node.js 22.1.0
+1. Python 3.12.3
 
 ## EXE の実行を確認した環境
 
-1. Windows 10 (64ビット)、 Windows 11 (64ビット) で確認。
+1. Windows 11 で確認。
 1. [Visual C++ 再頒布可能パッケージ](https://aka.ms/vs/17/release/vc_redist.x64.exe) (64ビット)
     * [再頒布可能パッケージの最新のサポートされているダウンロードをMicrosoft Visual C++する](https://learn.microsoft.com/ja-jp/cpp/windows/latest-supported-vc-redist?view=msvc-170) または <https://my.visualstudio.com/> からダウンロードする。
 1. .NET 8 SDK (64ビット)
@@ -25,14 +25,8 @@
 
 ## 注意点
 
-* System.Reflection.TypeExtensions.dll は Edge.js.CSharp が使用する古いバージョン(4.1.0 以下)で上書きする。そのため、**自作 DLL 側が .NET Core 3.1 など新しいバージョンの際に Reflection を使えない可能性がある。**
-* electron-edge-js が使用する、古いバージョンを指定する必要がある NuGet パッケージは下記の通り。**最新バージョンを使用できない可能性がある。**
-    * Microsoft.CodeAnalysis
-    * Microsoft.DotNet.InternalAbstractions (非推奨、更新無し)
-    * Microsoft.DotNet.PlatformAbstractions
-    * Microsoft.Extensions.DependencyModel
-
-* C:\Users\<実行中のユーザー>\.nuget ディレクトリーに存在すると、ビルドした EXE DLL が取り込まれていない状態でも .nuget にある DLL を参照してエラーにならないため、ビルド環境で EXE の実行を確認する場合は、 .nuget ディレクトリーを参照できない状態で確認する。
+* System.Reflection.TypeExtensions.dll は Edge.js.CSharp が使用するバージョンで上書きする。そのため、**自作 DLL 側が新しい .NET バージョンの際に Reflection を使えない可能性がある。**
+* C:\Users\\<実行中のユーザー>\\.nuget ディレクトリーにダウンロード済み NuGet パッケージが存在すると、ビルドした EXE に DLL が取り込まれていない状態でも .nuget にある DLL を参照して実行出来てしまうため、ビルド環境で EXE の実行を確認する場合は、 .nuget ディレクトリーを参照できない状態で確認する。
     (最終的にはビルド環境以外で確認した方が良い。)
 
 ## 準備
@@ -40,19 +34,19 @@
 * 初回は `install-npm.bat` を実行する。バッチの内容は下記の通り。
     * `npm install -g node-gyp` を実行する。
     * electron-app ディレクトリーで `npm install` を実行する。
-    * electron-app ディレクトリーで `npm run build-electron-edge-js` を実行する。
 * 初回や DLL を修正した場合、 `publish-dll.bat` を実行する。バッチの内容は下記の通り。
     * SampleLib.dll を発行し、 electron-app\Libraries に DLL を出力する。
-        * electron-app\Libraries に生成された下記ファイルを、 electron-app\node_modules\electron-edge-js\lib\bootstrap\bin\Release\netcoreapp1.1\runtimes\win\lib\netstandard1.3 ディレクトリーにを作成してコピーする。
+        * electron-app\Libraries に生成された下記ファイルを、 electron-app\node_modules\electron-edge-js\lib\bootstrap\bin\Release ディレクトリーにを作成してコピーする。
             * System.Diagnostics.FileVersionInfo.dll (electron-app\Libraries\refs ディレクトリーに存在。)
             * System.Text.Encoding.CodePages.dll (electron-app\Libraries\refs ディレクトリーに存在。)
             * Microsoft.DotNet.InternalAbstractions.dll
-        * electron-app\Libraries\refs に生成されたファイルを、 electron-app\node_modules\electron-edge-js\lib\bootstrap\bin\Release\netcoreapp1.1 ディレクトリーにコピーする。
-        * electron-app\Libraries に生成されたファイルを、 electron-app\node_modules\electron-edge-js\lib\bootstrap\bin\Release\netcoreapp1.1 ディレクトリーにコピーする。
+        * electron-app\Libraries\refs に生成されたファイルを、 electron-app\node_modules\electron-edge-js\lib\bootstrap\bin\Release ディレクトリーにコピーする。
+        * electron-app\Libraries に生成されたファイルを、 electron-app\node_modules\electron-edge-js\lib\bootstrap\bin\Release ディレクトリーにコピーする。
             (SampleLib* はコピーしないため、 CopyExcludedFiles.txt (除外一覧)に記載。)
     * EdgeJsCSharpSharedLib.dll を発行し、 electron-app\SharedLibraries に DLL を出力する。
-        * SharedLibraries\System.Reflection.TypeExtensions.dll を、 electron-app\node_modules\electron-edge-js\lib\bootstrap\bin\Release\netcoreapp1.1 ディレクトリーにコピーする。
-        * SharedLibraries\Edge.js.CSharp.dll を、 electron-app\node_modules\electron-edge-js\lib\bootstrap\bin\Release\netcoreapp1.1 ディレクトリーにコピーする。
+        * SharedLibraries\Edge.js.CSharp.dll を、 electron-app\node_modules\electron-edge-js\lib\bootstrap\bin\Release ディレクトリーにコピーする。
+        * SharedLibraries\System.Reflection.TypeExtensions.dll を、 electron-app\node_modules\electron-edge-js\lib\bootstrap\bin\Release ディレクトリーにコピーする。
+        * SharedLibraries\System.Text.Json.dll を、 electron-app\node_modules\electron-edge-js\lib\bootstrap\bin\Release ディレクトリーにコピーする。
 * EXE を作成する場合、 `build-executable.bat` を実行する。
 
 ## 実行
@@ -60,17 +54,17 @@
 * デバッグは、 electron-app ディレクトリーを Visual Studio Code で開いてデバッグを開始する。
 * EXE を作成する場合は、
     * electron-app ディレクトリー以下で、 `npm run build-portable` を実行する。
-    * electron-app\dist ディレクトリー以下にある EXE を実行する。
+    * electron-app\executableFile ディレクトリー以下にある EXE を実行する。
 
 ## SampleLib(DLL)の構成
 
-* TargetFramework は .NET 7 を指定。
+* TargetFramework は .NET 8 を指定。
 * プロジェクトファイル(csproj) > PropertyGroup に、下記2つを追記する。(edge-js で指定あり。)
     * `<PreserveCompilationContext>true</PreserveCompilationContext>`
     * `<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>`
 * 追加した NuGet パッケージは下記の通り。
     パッケージ名 |
-    -------|
+    ----- |
     Microsoft.CodeAnalysis |
     Microsoft.CSharp |
     Microsoft.DotNet.InternalAbstractions |
@@ -78,7 +72,6 @@
     Microsoft.Extensions.DependencyModel |
     Microsoft.NETCore.DotNetHost |
     Microsoft.NETCore.DotNetHostPolicy |
-    Newtonsoft.Json |
     System.Collections.NonGeneric |
     System.Collections.Specialized |
     System.Data.Common |
@@ -88,10 +81,11 @@
 
 ## EdgeJsCSharpSharedLib(DLL)の構成
 
-* TargetFramework は .NET Standard 1.6 を指定。([Edge.js.CSharp](https://www.nuget.org/packages/Edge.js.CSharp) の指定バージョンに合わせた。)
-    * edge-js の環境変数 `EDGE_USE_CORECLR` を指定した場合も、古い System.Reflection.TypeExtensions.dll (4.1.0 以下) を参照していて、それを使用するため。
-    * System.Reflection.TypeExtensions.dll (4.1.0) は、他の DLL とバージョン不整合を起こして SampleLib には追加できないため、 EdgeJsCSharpSharedLib を用意して取り出す。
+* TargetFramework は .NET Standard 2.1 を指定。([Edge.js.CSharp](https://www.nuget.org/packages/Edge.js.CSharp) の指定バージョンは .NET Standard 1.6。問題が発生する場合はバージョンの違いも調査観点に含める。)
+    * System.Reflection.TypeExtensions.dll は EdgeJsCSharpSharedLib が参照している DLL を使用する。
+    * System.Text.Json を参照しているため、コピー対象としてパッケージに追加する。
 * 追加した NuGet パッケージは下記の通り。
-    パッケージ名 | バージョン
-    -------|-------
-    Edge.js.CSharp | 1.2.0
+    パッケージ名 |
+    ----- |
+    Edge.js.CSharp |
+    System.Text.Json |

--- a/SampleLib/SampleLib/SampleLib.csproj
+++ b/SampleLib/SampleLib/SampleLib.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
     <PackageReference Include="Microsoft.NETCore.DotNetHost" Version="8.0.4" />
     <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy" Version="8.0.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />

--- a/electron-app/CopyExcludedFiles.txt
+++ b/electron-app/CopyExcludedFiles.txt
@@ -1,4 +1,4 @@
-# "node_modules\electron-edge-js\lib\bootstrap\bin\Release\netcoreapp1.1" にコピーしないファイルを列挙する。
+# コピーしないファイルを列挙する。
 Libraries\SampleLib.deps.json
 Libraries\SampleLib.dll
 Libraries\SampleLib.pdb

--- a/electron-app/package-lock.json
+++ b/electron-app/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "electron-edge-js": "^30.0.1"
+        "electron-edge-js": "^30.0.2"
       },
       "devDependencies": {
-        "electron": "^30.0.1",
+        "electron": "^30.0.2",
         "electron-builder": "^24.13.3"
       }
     },
@@ -1652,9 +1652,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-30.0.1.tgz",
-      "integrity": "sha512-iwxkI/n2wBd29NH7TH0ZY8aWGzCoKpzJz+D10u7aGSJi1TV6d4MSM3rWyKvT/UkAHkTKOEgYfUyCa2vWQm8L0g==",
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-30.0.2.tgz",
+      "integrity": "sha512-zv7T+GG89J/hyWVkQsLH4Y/rVEfqJG5M/wOBIGNaDdqd8UV9/YZPdS7CuFeaIj0H9LhCt95xkIQNpYB/3svOkQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1782,9 +1782,9 @@
       }
     },
     "node_modules/electron-edge-js": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/electron-edge-js/-/electron-edge-js-30.0.1.tgz",
-      "integrity": "sha512-xY/P8DOrE28lQ56qijbJ2utFKpDEB8x1x9naPv5cK+o0ReQFRKBKzGWwZLYP8dS9LcIzWQmfMwQCDHs2qOiClg==",
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/electron-edge-js/-/electron-edge-js-30.0.2.tgz",
+      "integrity": "sha512-6wKhirENnGPwbaSDZuHdxv6KtM1bAbydsOkZ2Y3v8VmRFTuEcJ81zOwiIehXtAK4rQy5GukCtxocbTD8HNUraQ==",
       "hasInstallScript": true,
       "dependencies": {
         "edge-cs": "npm:@agracio/edge-cs@^1.3.5",

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "set DEBUG_MODE=true && electron .",
-    "build-electron-edge-js": "node_modules\\electron-edge-js\\tools\\build.bat release 29.0.0",
     "build-portable": "electron-builder build --windows portable"
   },
   "author": "nakamurakko",
@@ -27,10 +26,10 @@
     ]
   },
   "dependencies": {
-    "electron-edge-js": "^30.0.1"
+    "electron-edge-js": "^30.0.2"
   },
   "devDependencies": {
-    "electron": "^30.0.1",
+    "electron": "^30.0.2",
     "electron-builder": "^24.13.3"
   }
 }

--- a/install-npm.bat
+++ b/install-npm.bat
@@ -2,6 +2,5 @@ cd electron-app
 
 call npm install -g node-gyp
 call npm install
-call npm run build-electron-edge-js
 
 pause

--- a/publish-dll.bat
+++ b/publish-dll.bat
@@ -1,7 +1,7 @@
 set RootDir=%~dp0
-set EdgeJSDir="node_modules\electron-edge-js\lib\bootstrap\bin\Release\netcoreapp1.1"
+set EdgeJSDir="node_modules\electron-edge-js\lib\bootstrap\bin\Release"
 
-if not exist "electron-app\Libraries" mkdir "electron-app\Libraries"
+
 
 @REM DLL を発行する。(SampleLib)
 cd %RootDir%"SampleLib"
@@ -10,14 +10,12 @@ call dotnet publish SampleLib -p:PublishProfile=SampleLib\Properties\PublishProf
 @REM electron-edge-js が参照する場所に Runtime をコピーする。
 cd %RootDir%"electron-app"
 
-if not exist %EdgeJSDir%"\runtimes\win\lib\netstandard1.3" mkdir %EdgeJSDir%"\runtimes\win\lib\netstandard1.3"
-
-copy /y Libraries\refs\System.Diagnostics.FileVersionInfo.dll %EdgeJSDir%"\runtimes\win\lib\netstandard1.3"
-copy /y Libraries\refs\System.Text.Encoding.CodePages.dll     %EdgeJSDir%"\runtimes\win\lib\netstandard1.3"
-copy /y Libraries\Microsoft.DotNet.InternalAbstractions.dll   %EdgeJSDir%"\runtimes\win\lib\netstandard1.3"
+copy /y Libraries\refs\System.Diagnostics.FileVersionInfo.dll %EdgeJSDir%
+copy /y Libraries\refs\System.Text.Encoding.CodePages.dll     %EdgeJSDir%
+copy /y Libraries\Microsoft.DotNet.InternalAbstractions.dll   %EdgeJSDir%
 
 copy /y Libraries\refs\*.* %EdgeJSDir%
-xcopy /y Libraries\*.*     %EdgeJSDir% /EXCLUDE:CopyExcludedFiles.txt
+xcopy /y /s Libraries\*.*  %EdgeJSDir% /EXCLUDE:CopyExcludedFiles.txt
 
 
 
@@ -28,7 +26,8 @@ call dotnet publish EdgeJsCSharpSharedLib -p:PublishProfile=EdgeJsCSharpSharedLi
 @REM electron-edge-js が参照する場所に Runtime をコピーする。
 cd %RootDir%"electron-app"
 
-copy /y SharedLibraries\System.Reflection.TypeExtensions.dll %EdgeJSDir%
 copy /y SharedLibraries\Edge.js.CSharp.dll                   %EdgeJSDir%
+copy /y SharedLibraries\System.Reflection.TypeExtensions.dll %EdgeJSDir%
+copy /y SharedLibraries\System.Text.Json.dll                 %EdgeJSDir%
 
 pause


### PR DESCRIPTION
- electron-edge-js v30.0.2 の破壊的変更に対応した。
  <https://github.com/agracio/electron-edge-js/releases/tag/v30.0.2>